### PR TITLE
Update switch.py to add Rapid Mode

### DIFF
--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -114,19 +114,6 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
 
 
         if (("settings" in device.commands) 
-            and (device.get("10degreeHeatingStatus", "N/A") != "N/A")):
-
-            description = HonSwitchEntityDescription(
-                key="10degreeHeatingStatus",
-                name="10° Heating",
-                icon="mdi:heat-wave",
-                translation_key="10_degree_heating",
-            )
-            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
-            await coordinator.async_request_refresh()
-
-
-        if (("settings" in device.commands) 
             and (device.get("ecoMode", "N/A") != "N/A")):
 
             description = HonSwitchEntityDescription(

--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -87,6 +87,19 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
             await coordinator.async_request_refresh()
 
 
+        if (("settings" in device.commands) 
+            and (device.get("rapidMode", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="rapidMode",
+                name="Rapid Mode",
+                icon="mdi:car-turbocharger",
+                translation_key="rapid_mode",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
+
+
     async_add_entities(appliances)
 
 

--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -100,6 +100,58 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
             await coordinator.async_request_refresh()
 
 
+        if (("settings" in device.commands) 
+            and (device.get("10degreeHeatingStatus", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="10degreeHeatingStatus",
+                name="10° Heating",
+                icon="mdi:heat-wave",
+                translation_key="10_degree_heating",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
+
+
+        if (("settings" in device.commands) 
+            and (device.get("10degreeHeatingStatus", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="10degreeHeatingStatus",
+                name="10° Heating",
+                icon="mdi:heat-wave",
+                translation_key="10_degree_heating",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
+
+
+        if (("settings" in device.commands) 
+            and (device.get("ecoMode", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="ecoMode",
+                name="Eco Mode",
+                icon="mdi:sprout",
+                translation_key="eco_mode",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
+
+
+        if (("settings" in device.commands) 
+            and (device.get("healthMode", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="healthMode",
+                name="Health Mode",
+                icon="mdi:heart",
+                translation_key="health_mode",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
+
+
     async_add_entities(appliances)
 
 


### PR DESCRIPTION
This update introduces support for "Rapid Mode" in devices where the rapidMode command is available and not marked as "N/A". A new HonSwitchEntityDescription is added, providing an entity to manage the Rapid Mode feature. The entity is appended to the appliances list.