### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This integration has been tested with the following devices.
 - HDQ 496AMBS/1-S
 
 ### Tumble Dryer
+- Hoover H-Dry 350, 9 kg Condenser Tumble Dryer HRE C9TBE-80
 - haier HD80-A3959
 - HRE H9A2TE-S
 - HLEH10A2TCEX-17


### PR DESCRIPTION
Adding Hoover H-Dry 350, 9 kg Condenser Tumble Dryer HRE C9TBE-80 to tested devices.