### PR TITLE
fix: token persistence and startup reliability

### DIFF
--- a/custom_components/hon/__init__.py
+++ b/custom_components/hon/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import device_registry as dr
 #from homeassistant.helpers.template import device_id as get_device_id
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ConfigEntryNotReady
 
 from .const import DOMAIN, PLATFORMS
 from .hon import HonConnection, get_hOn_mac
@@ -97,7 +97,12 @@ async def async_get_device_ids(hass, call):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hon = HonConnection(hass, entry)
-    await hon.async_authorize()
+    try:
+        result = await hon.async_authorize()
+    except Exception as e:
+        raise ConfigEntryNotReady(f"hOn connection failed: {e}") from e
+    if not result:
+        raise ConfigEntryNotReady("hOn authentication failed")
 
     # Log all appliances
     _LOGGER.debug(f"Appliances: {hon.appliances}")

--- a/custom_components/hon/config_flow.py
+++ b/custom_components/hon/config_flow.py
@@ -1,6 +1,7 @@
 
 import logging
 import voluptuous as vol
+import aiohttp
 
 from .hon import HonConnection
 from typing import Any
@@ -49,12 +50,14 @@ class HonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Test connection
         hon = HonConnection(None, None, self._email, self._password)
-        if( await hon.async_authorize() == False ):
-            errors = {}
-            errors["base"] = "auth_error"
-            await hon.async_close()
-            return self.async_show_form(step_id="user",data_schema=vol.Schema({vol.Required(CONF_EMAIL): str,vol.Required(CONF_PASSWORD): str}), errors=errors)
+        try:
+            auth_ok = await hon.async_authorize()
+        except aiohttp.ClientConnectorError:
+            auth_ok = False
         await hon.async_close()
+        if not auth_ok:
+            errors["base"] = "auth_error"
+            return self.async_show_form(step_id="user",data_schema=vol.Schema({vol.Required(CONF_EMAIL): str,vol.Required(CONF_PASSWORD): str}), errors=errors)
 
         return self.async_create_entry(
             title=self._email,
@@ -92,12 +95,15 @@ class HonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 
             # Test connection
             hon = HonConnection(None, None, config_entry.unique_id, user_input[CONF_PASSWORD])
-            if( await hon.async_authorize() == False ):
+            try:
+                auth_ok = await hon.async_authorize()
+            except aiohttp.ClientConnectorError:
+                auth_ok = False
+            await hon.async_close()
+            if not auth_ok:
                 errors = {}
                 errors["base"] = "auth_error"
-                await hon.async_close()
                 return self.async_show_form(step_id="reconfigure",data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}), errors=errors)
-            await hon.async_close()
 
             await self.async_set_unique_id(config_entry.unique_id)
 

--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -140,7 +140,31 @@ class HonConnection:
 
         return 0
 
+    async def async_try_saved_token(self) -> bool:
+        """Attempt to reuse a previously saved token, skipping the full OAuth2 flow."""
+        if not self._cognitoToken or not self._id_token:
+            return False
+        try:
+            url = f"{API_URL}/commands/v1/appliance"
+            async with self._session.get(url, headers=self._headers) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug(f"hOn saved token rejected (HTTP {resp.status}), falling back to full auth")
+                    return False
+                json_data = await resp.json()
+                self._appliances = json_data["payload"]["appliances"]
+                self._appliances = [a for a in self._appliances if "macAddress" in a]
+                self._appliances = [a for a in self._appliances if "applianceTypeId" in a]
+                self._start_time = time.time()
+                _LOGGER.debug("hOn authenticated using saved token")
+                return True
+        except Exception as e:
+            _LOGGER.debug(f"hOn saved token attempt failed ({e}), falling back to full auth")
+            return False
+
     async def async_authorize(self):
+
+        if await self.async_try_saved_token():
+            return True
 
         if await self.async_get_frontdoor_url(0) == 1:
             return False
@@ -197,6 +221,12 @@ class HonConnection:
                 _LOGGER.error("hOn Invalid Data ["+ str(resp.text()) + "] after sending command ["+ str(data)+ "] with headers [" + str(post_headers) + "]. Response: " + text)
                 return False
 
+        if self._entry is not None and self._hass is not None:
+            saved = {**self._entry.data}
+            saved[CONF_COGNITO_TOKEN] = self._cognitoToken
+            saved[CONF_ID_TOKEN] = self._id_token
+            self._hass.config_entries.async_update_entry(self._entry, data=saved)
+            _LOGGER.debug("hOn tokens persisted to config entry")
 
         url = f"{API_URL}/commands/v1/appliance"
         async with self._session.get(url,headers=self._headers) as resp:

--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -49,6 +49,10 @@ class HonConnection:
         self._coordinator_dict  = {}
         self._mobile_id = secrets.token_hex(8)
 
+        self._id_token = ""
+        self._refresh_token = ""
+        self._cognitoToken = ""
+
         # Only used during registration (Login/password check)
         if( email != None ) and ( password != None ):
             self._email = email


### PR DESCRIPTION
This PR fixes three related issues that caused the integration to fail authentication on every HA restart.

The hOn integration requires a full OAuth2 round-trip on every HA restart. If the network is briefly unavailable at boot (common in Docker setups, which is my case, where containers start before routing is fully established), the entry fails permanently with no retry and no useful error message in the UI.

This PR addresses the root cause and its side effects:

- Tokens obtained during a successful auth are reused on the next startup, making the OAuth2 flow the exception rather than the rule.
- When auth does fail (network down, expired token), HA retries automatically instead of giving up.
- The config flow no longer crashes with "Unknown error occurred" when a transient network error occurs during credential validation.

Tested on HA running in Docker.

I'm open to any feedback so we can integrate these fixes in next version of your plugin 🙏