### PR TITLE
Fix hOn health mode switch when setting key is missing

### DIFF
--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -151,6 +151,18 @@ class HonSwitchEntity(HonBaseSwitchEntity):
         super().__init__(coordinator, appliance, entity_description)
         self.invert = invert
 
+    def _setting_key(self) -> str:
+        return f"settings.{self.entity_description.key}"
+
+    def _setting(self):
+        return self._device.settings.get(self._setting_key())
+
+    def _target_value(self, turn_on: bool) -> str:
+        value = "1" if turn_on else "0"
+        if self.invert:
+            value = "0" if turn_on else "1"
+        return value
+
     @property
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
@@ -159,29 +171,40 @@ class HonSwitchEntity(HonBaseSwitchEntity):
         return self._device.get(self.entity_description.key, "0") == "1"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        setting = self._device.settings[f"settings.{self.entity_description.key}"]
-        if type(setting) == HonParameter:
-            return
-        if( self.invert == True ):
-            setting.value = setting.min if isinstance(setting, HonParameterRange) else 0
+        setting = self._setting()
+        if setting is not None:
+            if type(setting) == HonParameter:
+                return
+            if self.invert:
+                setting.value = setting.min if isinstance(setting, HonParameterRange) else 0
+            else:
+                setting.value = setting.max if isinstance(setting, HonParameterRange) else 1
+            await self._device.commands["settings"].send()
+            value = str(setting.value)
         else:
-            setting.value = setting.max if isinstance(setting, HonParameterRange) else 1
-        await self._device.commands["settings"].send()
-        self._device.set(self.entity_description.key, str(setting.value))
+            value = self._target_value(True)
+            await self.coordinator.async_set({self.entity_description.key: value})
+
+        self._device.set(self.entity_description.key, value)
         self.async_write_ha_state()
         self.coordinator.async_set_updated_data({})
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        setting = self._device.settings[f"settings.{self.entity_description.key}"]
-        if type(setting) == HonParameter:
-            return
-        if( self.invert == True ):
-            setting.value = setting.max if isinstance(setting, HonParameterRange) else 1
+        setting = self._setting()
+        if setting is not None:
+            if type(setting) == HonParameter:
+                return
+            if self.invert:
+                setting.value = setting.max if isinstance(setting, HonParameterRange) else 1
+            else:
+                setting.value = setting.min if isinstance(setting, HonParameterRange) else 0
+            await self._device.commands["settings"].send()
+            value = str(setting.value)
         else:
-            setting.value = setting.min if isinstance(setting, HonParameterRange) else 0
+            value = self._target_value(False)
+            await self.coordinator.async_set({self.entity_description.key: value})
 
-        await self._device.commands["settings"].send()
-        self._device.set(self.entity_description.key, str(setting.value))
+        self._device.set(self.entity_description.key, value)
         self.async_write_ha_state()
         self.coordinator.async_set_updated_data({})
 
@@ -198,12 +221,10 @@ class HonSwitchEntity(HonBaseSwitchEntity):
             _LOGGER.warning("HonSwitchEntity not available: DISCONNECTED")
             return False
         
-        setting_key = f"settings.{self.entity_description.key}"
-        setting = self._device.settings.get(setting_key, None)
+        setting = self._setting()
 
         if setting is None:
-            _LOGGER.warning("HonSwitchEntity not available: Key not found: %s", setting_key)
-            return False
+            return self._device.get(self.entity_description.key, None) is not None
 
         #_LOGGER.warning(setting)
         #if isinstance(setting, HonParameterRange) and len(setting.values) < 2:
@@ -215,4 +236,3 @@ class HonSwitchEntity(HonBaseSwitchEntity):
         self._attr_is_on = self.is_on
         if update:
             self.async_write_ha_state()
-


### PR DESCRIPTION
Fix HonSwitchEntity for devices that expose `healthMode` in the device context but do not provide a writable `settings.healthMode` parameter.

The integration currently creates the switch when `device.get("healthMode")` exists, but then marks it unavailable because `settings.healthMode` is missing, producing repeated warnings.

This patch keeps the normal `settings` path when available, falls back to `async_set` when the setting is not exposed in `device.settings`, and avoids marking the entity unavailable solely because `settings.<key>` is absent.
