### PR TITLE
Improve hOn entity handling and config-entry service lifecycle

### DIFF
--- a/custom_components/hon/__init__.py
+++ b/custom_components/hon/__init__.py
@@ -1,22 +1,15 @@
-import asyncio
 import logging
 import voluptuous as vol
-import aiohttp
-import json
-import urllib.parse
 import ast
 
-from homeassistant.components.persistent_notification import create
 from datetime import datetime
 from dateutil.tz import gettz
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_ID, CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers import device_registry as dr
-#from homeassistant.helpers.template import device_id as get_device_id
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN, PLATFORMS
@@ -25,6 +18,7 @@ from .device import HonDevice
 
 
 _LOGGER = logging.getLogger(__name__)
+SERVICE_REGISTRY = "service_registry"
 
 
 HON_SCHEMA = vol.Schema(
@@ -58,6 +52,11 @@ def get_parameters(call):
         parameters_str = str(parameters_str)
     return ast.literal_eval(parameters_str)
 
+
+def _minutes_until(target: datetime, now: datetime) -> int:
+    """Return the number of whole minutes until the target time."""
+    return max(0, int((target - now).total_seconds() / 60))
+
 #def get_device_ids(hass, call):
 #    device_ids = call.data.get("device_id", [])
     #entity_ids = call.data.get("entity_id", [])
@@ -78,8 +77,6 @@ def get_device_ids(hass, call):
 
     return list(device_ids)
 
-
-from homeassistant.helpers import entity_registry as er
 
 async def async_get_device_ids(hass, call):
     device_ids = set(call.data.get("device_id", []))
@@ -104,6 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = hon
+    hass.data[DOMAIN].setdefault(SERVICE_REGISTRY, set())
 
     for appliance in hon.appliances:
         
@@ -124,12 +122,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         if "start" in call.data:
             date = datetime.strptime(call.data.get("start"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            delay_time = int((date - datetime.now(tz)).seconds / 60)
+            delay_time = _minutes_until(date, datetime.now(tz))
 
         if "end" in call.data and "duration" in call.data:
             date = datetime.strptime(call.data.get("end"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
             duration = call.data.get("duration")
-            delay_time = int((date - datetime.now(tz)).seconds / 60 - duration)
+            delay_time = max(0, _minutes_until(date, datetime.now(tz)) - duration)
 
         parameters = {
             "delayTime": delay_time,
@@ -155,12 +153,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         if "start" in call.data:
             date = datetime.strptime(call.data.get("start"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            delay_time = int((date - datetime.now(tz)).seconds / 60)
+            delay_time = _minutes_until(date, datetime.now(tz))
 
         if "end" in call.data and "duration" in call.data:
             date = datetime.strptime(call.data.get("end"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
             duration = call.data.get("duration")
-            delay_time = int((date - datetime.now(tz)).seconds / 60 - duration)
+            delay_time = max(0, _minutes_until(date, datetime.now(tz)) - duration)
 
         parameters = {
             "delayTime": delay_time,
@@ -184,7 +182,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         tz = gettz(hass.config.time_zone)
         if "end" in call.data:
             date = datetime.strptime(call.data.get("end"), "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            delay_time = int((date - datetime.now(tz)).seconds / 60)
+            delay_time = _minutes_until(date, datetime.now(tz))
 
         parameters = {
                     "haier_MainWashSpeed": "50",
@@ -441,29 +439,57 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 
-    hass.services.async_register(DOMAIN, "turn_on_washingmachine", handle_washingmachine_start)
-    hass.services.async_register(DOMAIN, "turn_on_oven", handle_oven_start)
-    hass.services.async_register(DOMAIN, "turn_on_dishwasher", handle_dishwasher_start)
-    hass.services.async_register(DOMAIN, "turn_on_purifier", handle_purifier_start)
-    hass.services.async_register(DOMAIN, "set_auto_mode_purifier", handle_purifier_automode)
-    hass.services.async_register(DOMAIN, "set_sleep_mode_purifier", handle_purifier_sleepmode)
-    hass.services.async_register(DOMAIN, "set_max_mode_purifier", handle_purifier_maxmode)
+    services = {
+        "turn_on_washingmachine": handle_washingmachine_start,
+        "turn_on_oven": handle_oven_start,
+        "turn_on_dishwasher": handle_dishwasher_start,
+        "turn_on_purifier": handle_purifier_start,
+        "set_auto_mode_purifier": handle_purifier_automode,
+        "set_sleep_mode_purifier": handle_purifier_sleepmode,
+        "set_max_mode_purifier": handle_purifier_maxmode,
+        "set_mode": handle_set_mode,
+        "turn_off": handle_turn_off,
+        "turn_light_on": handle_light_on,
+        "turn_light_off": handle_light_off,
+        "send_custom_request": handle_custom_request,
+        "climate_turn_health_mode_on": handle_health_mode_on,
+        "climate_turn_health_mode_off": handle_health_mode_off,
+        "start_program": handle_start_program,
+        "update_settings": handle_update_settings,
+        "get_setting": async_get_setting,
+    }
 
-    hass.services.async_register(DOMAIN, "set_mode", handle_set_mode)
-    hass.services.async_register(DOMAIN, "turn_off", handle_turn_off)
-    hass.services.async_register(DOMAIN, "turn_light_on",   handle_light_on)
-    hass.services.async_register(DOMAIN, "turn_light_off",  handle_light_off)
-    hass.services.async_register(DOMAIN, "send_custom_request",  handle_custom_request)
-    hass.services.async_register(DOMAIN, "climate_turn_health_mode_on",   handle_health_mode_on)
-    hass.services.async_register(DOMAIN, "climate_turn_health_mode_off",  handle_health_mode_off)
+    registered_services = hass.data[DOMAIN][SERVICE_REGISTRY]
+    for service_name, handler in services.items():
+        if service_name in registered_services:
+            continue
+        hass.services.async_register(
+            domain=DOMAIN,
+            service=service_name,
+            service_func=handler,
+            schema=None,
+        )
+        registered_services.add(service_name)
 
-    hass.services.async_register(DOMAIN, "start_program",   handle_start_program)
-    hass.services.async_register(DOMAIN, "update_settings", handle_update_settings)
-    hass.services.async_register(
-        domain=DOMAIN,
-        service="get_setting",
-        service_func=async_get_setting,
-        schema=None 
-    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if not unload_ok:
+        return False
+
+    hon = hass.data[DOMAIN].pop(entry.unique_id, None)
+    if hon is not None:
+        await hon.async_close()
+
+    remaining_entries = [
+        key for key in hass.data.get(DOMAIN, {}) if key != SERVICE_REGISTRY
+    ]
+    if not remaining_entries:
+        for service_name in hass.data[DOMAIN].get(SERVICE_REGISTRY, set()):
+            hass.services.async_remove(DOMAIN, service_name)
+        hass.data.pop(DOMAIN, None)
 
     return True

--- a/custom_components/hon/command.py
+++ b/custom_components/hon/command.py
@@ -71,7 +71,24 @@ class HonCommand:
     @property
     def settings(self):
         """Parameters with typology enum and range"""
-        return {s: self._parameters.get(s) for s in self.setting_keys if self._parameters.get(s) is not None}
+        if not self._multi:
+            return {
+                key: parameter
+                for key, parameter in self._parameters.items()
+                if not isinstance(parameter, HonParameterFixed)
+            }
+
+        result = {}
+        for key in self.setting_keys:
+            parameter = self._parameters.get(key)
+            if parameter is None:
+                for command in self._multi.values():
+                    parameter = command.parameters.get(key)
+                    if parameter is not None:
+                        break
+            if parameter is not None:
+                result[key] = parameter
+        return result
 
     def dump(self):
         text = ""

--- a/custom_components/hon/const.py
+++ b/custom_components/hon/const.py
@@ -27,12 +27,10 @@ PLATFORMS = [
     "sensor",
     "binary_sensor",
     "button",
-    "switch"
-]
-
-'''
+    "switch",
     "select",
-    "number" '''
+    "number",
+]
 
 AUTH_API        = "https://account2.hon-smarthome.com/SmartHome"
 API_URL         = "https://api-iot.he.services"

--- a/custom_components/hon/device.py
+++ b/custom_components/hon/device.py
@@ -195,12 +195,12 @@ class HonDevice(CoordinatorEntity):
         if( "settings" not in self._commands ):
             raise ValueError("No command to update settings of the device")
         command = self._commands.get("settings")
-        self.update_command(command, self.attributes["parameters"])
+        self.update_command(command, self.attributes.get("parameters", {}))
         self.update_command(command, parameters)
 
         # Update for next command (in case no refresh happens yet)
         for key in command.parameters.keys():
-            self.attributes["parameters"][key] = command.parameters.get(key).value
+            self.attributes.setdefault("parameters", {})[key] = command.parameters.get(key).value
 
         return command
 
@@ -208,17 +208,32 @@ class HonDevice(CoordinatorEntity):
         if( "startProgram" not in self._commands ):
             raise ValueError("No command to start the device")
         command = self._commands.get("startProgram")
-        command.set_program(program)
+        if program is not None:
+            command.set_program(program)
         # Return the new default command
         command = self._commands.get("startProgram")
-        self.update_command(command, self.attributes["parameters"])
+        self.update_command(command, self.attributes.get("parameters", {}))
         self.update_command(command, parameters)
     
         # Update for next command (in case no refresh happens yet)
         for key in command.parameters.keys():
-            self.attributes["parameters"][key] = command.parameters.get(key).value
+            self.attributes.setdefault("parameters", {})[key] = command.parameters.get(key).value
 
         return command
+
+    def get_setting(self, setting_key):
+        command_name, parameter_key = setting_key.split(".", 1)
+        command = self._commands.get(command_name)
+        if command is None:
+            return None
+        return command.settings.get(parameter_key)
+
+    def has_current_setting(self, setting_key):
+        command_name, parameter_key = setting_key.split(".", 1)
+        command = self._commands.get(command_name)
+        if command is None:
+            return False
+        return parameter_key in command.parameters
 
     def stop_command(self, parameters = {}):
         if( "stopProgram" in self._commands ):

--- a/custom_components/hon/number.py
+++ b/custom_components/hon/number.py
@@ -1,76 +1,75 @@
-import logging
 from .device import HonDevice
 from .const import DOMAIN
-from .parameter import HonParameterFixed, HonParameterEnum, HonParameterRange, HonParameterProgram
+from .parameter import HonParameterRange
 
 from homeassistant.core import callback
-from homeassistant.const import UnitOfTemperature, UnitOfTime, REVOLUTIONS_PER_MINUTE
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.update_coordinator import (CoordinatorEntity)
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers import translation
-
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 
+
 default_values = {
-    "delayTime" : {
-        "icon" : "mdi:timer-plus",
-        "native_unit_of_measurement" : UnitOfTime.MINUTES
+    "delayTime": {
+        "icon": "mdi:timer-plus",
+        "native_unit_of_measurement": UnitOfTime.MINUTES,
     },
-    "rinseIterations" : {
-        "icon" : "mdi:rotate-right",
+    "rinseIterations": {
+        "icon": "mdi:rotate-right",
     },
-    "mainWashTime" : {
-        "icon" : "mdi:clock-start",
-        "native_unit_of_measurement" : UnitOfTime.MINUTES
+    "mainWashTime": {
+        "icon": "mdi:clock-start",
+        "native_unit_of_measurement": UnitOfTime.MINUTES,
     },
-    "dryLevel" : {
-        "icon" : "mdi:hair-dryer",
+    "dryLevel": {
+        "icon": "mdi:hair-dryer",
     },
-    "tempLevel" : {
-        "icon" : "mdi:thermometer",
-        "native_unit_of_measurement" : UnitOfTemperature.CELSIUS
+    "tempLevel": {
+        "icon": "mdi:thermometer",
+        "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
     },
-    "antiCreaseTime" : {
-        "icon" : "mdi:timer",
-        "native_unit_of_measurement" : UnitOfTime.MINUTES
+    "antiCreaseTime": {
+        "icon": "mdi:timer",
+        "native_unit_of_measurement": UnitOfTime.MINUTES,
     },
-    "sterilizationStatus" : {
-        "icon" : "mdi:clock-start",
+    "sterilizationStatus": {
+        "icon": "mdi:clock-start",
     },
 }
 
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     hon = hass.data[DOMAIN][entry.unique_id]
-    translations = await translation.async_get_translations(hass, hass.config.language, "entity")
+    translations = await translation.async_get_translations(
+        hass, hass.config.language, "entity"
+    )
 
     appliances = []
     for appliance in hon.appliances:
-
-        # Get or Create Coordinator
         coordinator = await hon.async_get_coordinator(appliance)
-        device = coordinator.device
 
-        #command = device.settings_command()
+        for key, parameter in coordinator.device.settings.items():
+            if not isinstance(parameter, HonParameterRange):
+                continue
 
-        for key in coordinator.device.settings:
-            parameter = coordinator.device.settings[key]
-            if(isinstance(parameter, HonParameterRange)
-            and key.startswith("startProgram.")):
+            default_value = default_values.get(parameter.key, {})
+            translation_key = (
+                coordinator.device.appliance_type.lower() + "_" + parameter.key.lower()
+            )
 
-                default_value = default_values.get(parameter.key, {})
-                translation_key = coordinator.device.appliance_type.lower() + '_' + parameter.key.lower()
-
-                description = NumberEntityDescription(
-                    key=key,
-                    name=translations.get(f"component.hon.entity.number.{translation_key}.name", parameter.key),
-                    entity_category=EntityCategory.CONFIG,
-                    translation_key = translation_key,
-                    icon=default_value.get("icon", None),
-                    unit_of_measurement=default_value.get("unit_of_measurement", None),
-                )
-                appliances.extend([HonNumber(hon, coordinator, appliance, description)])
-
+            description = NumberEntityDescription(
+                key=key,
+                name=translations.get(
+                    f"component.hon.entity.number.{translation_key}.name", parameter.key
+                ),
+                entity_category=EntityCategory.CONFIG,
+                translation_key=translation_key,
+                icon=default_value.get("icon"),
+                native_unit_of_measurement=default_value.get(
+                    "native_unit_of_measurement"
+                ),
+            )
+            appliances.append(HonNumber(hon, coordinator, appliance, description))
 
     async_add_entities(appliances)
 
@@ -78,32 +77,46 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class HonNumber(HonDevice, NumberEntity):
     def __init__(self, hon, coordinator, appliance, description) -> None:
         super().__init__(hon, coordinator, appliance)
-
-        self._coordinator = coordinator
         self._device = coordinator.device
-        self._data = self._device.settings[description.key]
         self.entity_description = description
         self._attr_unique_id = f"{self._mac}-number-{description.key}"
+        self._refresh_bounds()
 
-        if isinstance(self._data, HonParameterRange):
-            self._attr_native_max_value = self._data.max
-            self._attr_native_min_value = self._data.min
-            self._attr_native_step = self._data.step
+    def _get_setting(self):
+        return self._device.get_setting(self.entity_description.key)
 
-    @property
-    def native_value(self) -> float | None:
-        return self._device.get(self.entity_description.key)
-
-    async def async_set_native_value(self, value: float) -> None:
-        self._device.settings[self.entity_description.key].value = value
-        await self.coordinator.async_request_refresh()
-
-    @callback
-    def _handle_coordinator_update(self):
-        setting = self._device.settings[self.entity_description.key]
+    def _refresh_bounds(self):
+        setting = self._get_setting()
         if isinstance(setting, HonParameterRange):
             self._attr_native_max_value = setting.max
             self._attr_native_min_value = setting.min
             self._attr_native_step = setting.step
-        self._attr_native_value = setting.value
+
+    @property
+    def native_value(self) -> float | None:
+        setting = self._get_setting()
+        return None if setting is None else setting.value
+
+    async def async_set_native_value(self, value: float) -> None:
+        command_name, parameter_name = self.entity_description.key.split(".", 1)
+        if command_name == "settings":
+            command = self._device.settings_command({parameter_name: value})
+            await command.send()
+            await self.coordinator.async_request_refresh()
+            return
+
+        self._device.start_command(parameters={parameter_name: value})
+        self.coordinator.async_set_updated_data({})
+
+    @callback
+    def _handle_coordinator_update(self):
+        setting = self._get_setting()
+        self._refresh_bounds()
+        self._attr_native_value = None if setting is None else setting.value
         self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._device.has_current_setting(
+            self.entity_description.key
+        )

--- a/custom_components/hon/select.py
+++ b/custom_components/hon/select.py
@@ -1,102 +1,118 @@
 import logging
 
 from homeassistant.core import callback
-from homeassistant.const import UnitOfTemperature, UnitOfTime, REVOLUTIONS_PER_MINUTE
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers import translation
 
 from .const import DOMAIN
 from .device import HonDevice
-from .parameter import HonParameterFixed, HonParameterEnum, HonParameterRange, HonParameterProgram
+from .parameter import HonParameterFixed, HonParameterEnum, HonParameterProgram
 
 
 _LOGGER = logging.getLogger(__name__)
 
 default_values = {
-    "windSpeed" : {
-        "icon" : "mdi:fan",
+    "windSpeed": {
+        "icon": "mdi:fan",
     },
-    "windDirectionHorizontal" : {
-        "icon" : "mdi:swap-horizontal",
+    "windDirectionHorizontal": {
+        "icon": "mdi:swap-horizontal",
     },
-    "windDirectionVertical" : {
-        "icon" : "mdi:swap-vertical",
-    }
+    "windDirectionVertical": {
+        "icon": "mdi:swap-vertical",
+    },
 }
 
 
-
-async def async_setup_entry(hass, entry , async_add_entities) -> None:
-
+async def async_setup_entry(hass, entry, async_add_entities) -> None:
     hon = hass.data[DOMAIN][entry.unique_id]
-    translations = await translation.async_get_translations(hass, hass.config.language, "entity")
+    translations = await translation.async_get_translations(
+        hass, hass.config.language, "entity"
+    )
 
     appliances = []
     for appliance in hon.appliances:
-
-        # Get or Create Coordinator
         coordinator = await hon.async_get_coordinator(appliance)
-        device = coordinator.device
 
-        #command = device.settings_command()
+        for key, parameter in coordinator.device.settings.items():
+            if not isinstance(parameter, (HonParameterEnum, HonParameterProgram)):
+                continue
+            if key.startswith("settings.") and set(parameter.values) == {"0", "1"}:
+                continue
 
-        for key in coordinator.device.settings:
-            parameter = coordinator.device.settings[key]
-            if((isinstance(parameter, HonParameterEnum) or isinstance(parameter, HonParameterProgram))
-            and key.startswith("startProgram.")):
+            default_value = default_values.get(parameter.key, {})
+            translation_key = (
+                coordinator.device.appliance_type.lower() + "_" + parameter.key.lower()
+            )
 
-                default_value = default_values.get(parameter.key, {})
-                translation_key = coordinator.device.appliance_type.lower() + '_' + parameter.key.lower()
-
-                description = SelectEntityDescription(
-                    key=key,
-                    name=translations.get(f"component.hon.entity.select.{translation_key}.name", parameter.key),
-                    entity_category=EntityCategory.CONFIG,
-                    translation_key = translation_key,
-                    icon=default_value.get("icon", None),
-                    unit_of_measurement=default_value.get("unit_of_measurement", None),
-                )
-                appliances.extend([HonSelect(hon, coordinator, appliance, parameter, description)])
-
+            description = SelectEntityDescription(
+                key=key,
+                name=translations.get(
+                    f"component.hon.entity.select.{translation_key}.name", parameter.key
+                ),
+                entity_category=EntityCategory.CONFIG,
+                translation_key=translation_key,
+                icon=default_value.get("icon"),
+            )
+            appliances.append(HonSelect(hon, coordinator, appliance, description))
 
     async_add_entities(appliances)
 
 
-
 class HonSelect(HonDevice, SelectEntity):
-    def __init__(self, hon, coordinator, appliance, parameter, description ) -> None:
+    def __init__(self, hon, coordinator, appliance, description) -> None:
         super().__init__(hon, coordinator, appliance)
-
-        self._parameter         = parameter
-        self._device            = coordinator.device
+        self._device = coordinator.device
         self.entity_description = description
-
         self._attr_unique_id = f"{self._mac}-select-{description.key}"
+        self._refresh_options()
 
-        if not isinstance(self._device.settings[self.entity_description.key], HonParameterFixed):
-            self._attr_options: list[str] = self._device.settings[self.entity_description.key].values
+    def _get_setting(self):
+        return self._device.get_setting(self.entity_description.key)
+
+    def _refresh_options(self):
+        setting = self._get_setting()
+        if setting is None:
+            self._attr_options = []
+        elif isinstance(setting, HonParameterFixed):
+            self._attr_options = [setting.value]
         else:
-            self._attr_options: list[str] = [self._device.settings[self.entity_description.key].value]
-
+            self._attr_options = list(setting.values)
 
     @property
     def current_option(self) -> str | None:
-        value = self._device.settings[self.entity_description.key].value
-        if value is None or value not in self._attr_options:
+        setting = self._get_setting()
+        if setting is None:
+            return None
+        value = setting.value
+        if value not in self._attr_options:
             return None
         return value
 
     async def async_select_option(self, option: str) -> None:
-        self._device.settings[self.entity_description.key].value = option
-        await self.coordinator.async_request_refresh()
+        command_name, parameter_name = self.entity_description.key.split(".", 1)
+        if command_name == "settings":
+            command = self._device.settings_command({parameter_name: option})
+            await command.send()
+            await self.coordinator.async_request_refresh()
+            return
+
+        if parameter_name == "program":
+            self._device.start_command(program=option)
+        else:
+            self._device.start_command(parameters={parameter_name: option})
+        self.coordinator.async_set_updated_data({})
 
     @callback
     def _handle_coordinator_update(self):
-        setting = self._device.settings[self.entity_description.key]
-        if not isinstance(self._device.settings[self.entity_description.key], HonParameterFixed):
-            self._attr_options: list[str] = setting.values
-        else:
-            self._attr_options = [setting.value]
-        self._attr_native_value = setting.value
+        setting = self._get_setting()
+        self._refresh_options()
+        self._attr_current_option = None if setting is None else setting.value
         self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._device.has_current_setting(
+            self.entity_description.key
+        )


### PR DESCRIPTION
 ## Summary

  This PR improves how the hOn integration exposes and updates selectable/range settings, and fixes config-entry
  lifecycle issues around service registration and unload handling.

  ## What Changed

  - reworked number entities to expose all range-based device settings instead of only startProgram.* values
  - reworked select entities to expose enum/program settings more broadly, while filtering out simple binary settings.*
    values
  - updated number/select entities to resolve settings dynamically from the current device state, refresh bounds/options
    on coordinator updates, and report availability only when the setting exists for the active command/program
  - changed entity writes so settings.* values are sent through settings_command(...).send(), while startProgram.*
    values update the active start command without forcing a full refresh
  - added helper methods on HonDevice to fetch a setting by key and check whether a setting is currently valid for the
    active command
  - fixed delayed-start calculations to clamp negative values and use a shared minute-calculation helper
  - centralized service registration so services are only registered once even with multiple config entries
  - added async_unload_entry to unload platforms, close the connection, and remove registered services when the last
    entry is unloaded

  ## Why

  These changes make entity behavior match the currently active command/program more reliably, prevent stale or invalid
  settings from being exposed, and avoid service-registration/leak issues when reloading or unloading the integration.

  ## Testing

  - Not run locally in this workspace.