### PR TITLE
Add support for Air to Water Heat Pump

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ This integration has been tested with the following devices.
 
 ### Heat Pump Water Heater
 - Haier HP150M8-9 (only programs are working)
+
+### Air to Water Heat Pump
+- Haier Monobloc GT R290

--- a/custom_components/hon/const.py
+++ b/custom_components/hon/const.py
@@ -53,7 +53,8 @@ class APPLIANCE_TYPE(IntEnum):
     DISH_WASHER     = 9,
     CLIMATE         = 11,
     FRIDGE          = 14,
-    TV              = 25
+    TV              = 25,
+    AIR_TO_WATER    = 27
 
 APPLIANCE_DEFAULT_NAME = {
     "1": "Washing Machine",
@@ -66,6 +67,7 @@ APPLIANCE_DEFAULT_NAME = {
     "11": "Climate",
     "14": "Fridge",
     "25": "TV",
+    "27": "Air to Water",
 }
 
 CLIMATE_FAN_MODE = {

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -83,6 +83,12 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if device.has("tempZ3"):
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ3",      "Temperature zone 3")])
 
+        # AW Domestic hot water sensors
+        if device.has("tempDhw"):
+            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempDhw",      "Temperature domestic hot water")])
+        if device.has("tempSelDhw"):
+            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempSelDhw",   "Selected temperature domestic hot water")])
+
         if device.has("remainingTimeMM"):
             appliances.extend([HonBaseStart(hass, coordinator, entry, appliance)])
             appliances.extend([HonBaseEnd(hass, coordinator, entry, appliance)])
@@ -218,6 +224,10 @@ class HonBaseMode(HonBaseSensorEntity):
 
         if( self._type_id == APPLIANCE_TYPE.PURIFIER ):
             self.translation_key    = "purifier_mode"
+
+        if( self._type_id == APPLIANCE_TYPE.AIR_TO_WATER ):
+            self.translation_key    = "air_to_water_mode"
+            self._attr_icon         = "mdi:heat-pump-outline"
             
 
     def coordinator_update(self):

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -145,6 +145,14 @@
                     "4": "Max"
                 }
             },
+            "air_to_water_mode" : {
+                "state": {
+                    "0": "Off",
+                    "2": "Zones Heat",
+                    "3": "DHW",
+                    "8": "Zones Heat + DHW"
+                }
+            },
             "voc" : {
                 "state": {
                     "1": "Good",


### PR DESCRIPTION
 ## Summary
This PR adds support for Air To Water Heat Pump.
It has been tested with Haier Monobloc GT R290, in specific with model AW122MXGHA but should work for the remaining.

## What Changed
* Adds Air to Water appliance type
* Adds support for Domestic Hot Water sensors
* Adds working modes english translations for 
  * Off
  * Domestic Hot Water
  * Zones Heat
  * Zones Heat + Domestic Hot Water

## Testing
* The changes were done in my fork and ran with success in my Home Assistant server
<img width="377" height="711" alt="image" src="https://github.com/user-attachments/assets/a27acee7-f218-4683-ae06-7202f2a07890" />
