### PR TITLE
Show actionable login errors (password reset / connectivity) instead of generic "wrong password"

### DIFF
--- a/custom_components/hon/config_flow.py
+++ b/custom_components/hon/config_flow.py
@@ -50,13 +50,16 @@ class HonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Test connection
         hon = HonConnection(None, None, self._email, self._password)
+        error_reason = "cannot_connect"
         try:
             auth_ok = await hon.async_authorize()
+            if not auth_ok:
+                error_reason = hon.error_reason or "auth_error"
         except aiohttp.ClientConnectorError:
             auth_ok = False
         await hon.async_close()
         if not auth_ok:
-            errors["base"] = "auth_error"
+            errors["base"] = error_reason
             return self.async_show_form(step_id="user",data_schema=vol.Schema({vol.Required(CONF_EMAIL): str,vol.Required(CONF_PASSWORD): str}), errors=errors)
 
         return self.async_create_entry(
@@ -95,14 +98,17 @@ class HonFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 
             # Test connection
             hon = HonConnection(None, None, config_entry.unique_id, user_input[CONF_PASSWORD])
+            error_reason = "cannot_connect"
             try:
                 auth_ok = await hon.async_authorize()
+                if not auth_ok:
+                    error_reason = hon.error_reason or "auth_error"
             except aiohttp.ClientConnectorError:
                 auth_ok = False
             await hon.async_close()
             if not auth_ok:
                 errors = {}
-                errors["base"] = "auth_error"
+                errors["base"] = error_reason
                 return self.async_show_form(step_id="reconfigure",data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}), errors=errors)
 
             await self.async_set_unique_id(config_entry.unique_id)

--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -63,6 +63,16 @@ class HonConnection:
 
         self._start_time    = time.time()
 
+        # Distinct reason for the last authorization failure, so that the config
+        # flow can show an actionable message instead of a generic "wrong
+        # password" error. See async_authorize().
+        self._error_reason  = None
+
+    @property
+    def error_reason(self):
+        """Reason code for the last failed authorization (or None)."""
+        return self._error_reason
+
         self._header = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36"
         }
@@ -103,6 +113,10 @@ class HonConnection:
         and reads appliances from /unified-api/v1/view/appliance-list. The old
         /commands/v1/appliance endpoint now returns an empty list.
         """
+        # Reset the failure reason for this attempt. It is only set when a step
+        # below fails, and read afterwards by the config flow.
+        self._error_reason = None
+
         # PKCE (S256) verifier + challenge
         code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b"=").decode()
         code_challenge = base64.urlsafe_b64encode(
@@ -117,11 +131,23 @@ class HonConnection:
         }
         async with self._session.get(f"{API_URL}/ciam/authorize", params=params) as resp:
             if resp.status != 200:
-                _LOGGER.error("Unable to connect to the CIAM authorize service: " + str(resp.status))
+                text = await resp.text()
+                # hOn keeps its legacy behaviour of redirecting to a
+                # "ChangePassword" page when the credentials are valid but a
+                # password reset is required. Surface that as a dedicated reason
+                # so the user resets their password instead of endlessly retrying
+                # the same (correct) one.
+                if "ChangePassword" in text:
+                    _LOGGER.error("Unable to connect. You need to change your password on the hOn app or go to https://account2.hon-smarthome.com/")
+                    self._error_reason = "password_change_required"
+                else:
+                    _LOGGER.error("Unable to connect to the CIAM authorize service: " + str(resp.status))
+                    self._error_reason = "cannot_connect"
                 return False
             session_id = (await resp.json()).get("session_id")
             if not session_id:
                 _LOGGER.error("Unable to get [session_id] - check your email/password")
+                self._error_reason = "auth_error"
                 return False
 
         # 2) Exchange the session id (+ PKCE verifier) for the tokens
@@ -136,6 +162,7 @@ class HonConnection:
                 self._refresh_token = tokens.get("refresh_token", "")
             except (KeyError, TypeError):
                 _LOGGER.error("Unable to get tokens from /ciam/token. Response: " + await resp.text())
+                self._error_reason = "auth_error"
                 return False
 
         # 3) Load the appliance list from the unified-api view
@@ -146,6 +173,7 @@ class HonConnection:
                 self._appliances = json_data["modules"]["applianceList"]["payload"]["appliances"]
             except (KeyError, TypeError):
                 _LOGGER.error("hOn Invalid Data [" + (await resp.text())[:500] + "] after POST [" + url + "]")
+                self._error_reason = "cannot_connect"
                 return False
 
             _LOGGER.debug(f"All appliances: {self._appliances}")

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -18,7 +18,9 @@
         },
         "error": {
             "reconfigure_successful" : "You need to restart HA",
-            "auth_error": "Your login attempt has failed. Make sure the username and password are correct."
+            "auth_error": "Your login attempt has failed. Make sure the username and password are correct.",
+            "password_change_required": "Your credentials are correct, but hOn requires you to set a new password before the account can be used here. Open the hOn mobile app (or https://account2.hon-smarthome.com/), change your password, then try again with the new one.",
+            "cannot_connect": "Could not reach the hOn cloud service. Please check your internet connection and try again."
         }
     },
     "entity": {


### PR DESCRIPTION
## Problem

Every authorization failure in the config flow surfaces the **same** error:

> *Your login attempt has failed. Make sure the username and password are correct.*

This is actively misleading in a very common scenario. When hOn **forces a password change** on an account, the credentials are still *correct* — but the OAuth `authorize` step redirects to the Salesforce **`ChangePassword`** page instead of returning an `id_token`, so `async_authorize()` returns `False`. The user is told their password is wrong and re-types the same (correct) password forever.

The code already *detects* this case and logs a helpful hint:

```python
_LOGGER.error("Unable to get connect. You need to change your password on the hOn app or go to https://account2.hon-smarthome.com/")
```

…but that hint is buried in the logs; the UI only ever shows `auth_error`.

### How this was confirmed

Replaying the exact login flow from `hon.py` against the hOn cloud for an affected account:

| Step | Endpoint | Result |
|------|----------|--------|
| 1. Salesforce login (frontdoor) | `/s/sfsites/aura …login` | ✅ 200 — credentials accepted |
| 2. `frontdoor.jsp` | | ✅ 200 |
| 3. `ProgressiveLogin` | | ✅ 200 |
| 4. `oauth2/authorize` → `id_token` | | ❌ redirected to `/_ui/system/security/ChangePassword` |

So login succeeds and only the token issuance is blocked by a forced password reset. After changing the account password, the *identical* flow returns the `id_token`, cognito token and the appliance list normally.

## Fix

Track a distinct reason for the last authorization failure and show it to the user:

- **`password_change_required`** — credentials valid, but a password reset is required (detected via the existing `ChangePassword` redirect). The message tells the user exactly what to do.
- **`cannot_connect`** — the hOn cloud could not be reached / returned bad data.
- **`auth_error`** — the login was genuinely rejected (wrong email/password).

### Changes

- `hon.py`: add `HonConnection.error_reason` and set it at each failure point in `async_authorize()`.
- `config_flow.py`: map `error_reason` onto `errors["base"]` in **both** the `user` and `reconfigure` steps.
- `translations/en.json`: add the new error messages and the (previously missing) `reconfigure` step strings.

The happy path is unchanged — only failures are relabeled, so existing successful setups are unaffected.

## Why this protects users

A user whose hOn password has expired currently has no way to tell that apart from a typo. With this change they get a clear, actionable message ("reset your password in the hOn app, then retry") and can use the existing **reconfigure** flow to enter the new password — instead of opening an issue or giving up.