### PR TITLE
Fix climate: optimistic state for temperature/fan/swing + fix watcher timer leak

### DIFF
--- a/custom_components/hon/climate.py
+++ b/custom_components/hon/climate.py
@@ -56,7 +56,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher   import async_dispatcher_connect
-from homeassistant.helpers.event        import async_track_time_interval
+from homeassistant.helpers.event        import async_call_later
 from homeassistant.helpers              import config_validation as cv, entity_platform
 from .const import(
     DOMAIN, 
@@ -257,7 +257,9 @@ class HonClimateEntity(CoordinatorEntity, ClimateEntity):
         await self._device.settings_command(parameters).send()
 
     def start_watcher(self, timedelta=timedelta(seconds=8)):
-        self._watcher = async_track_time_interval(self._hass, self.async_update_after_state_change, timedelta)
+        if self._watcher is not None:
+            self._watcher()
+        self._watcher = async_call_later(self._hass, timedelta, self.async_update_after_state_change)
         self.async_write_ha_state()
 
     async def async_update_after_state_change(self, now: Optional[datetime] = None) -> None:
@@ -350,6 +352,8 @@ class HonClimateEntity(CoordinatorEntity, ClimateEntity):
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return False
         await self._device.settings_command({'tempSel': temperature}).send()
+        self._attr_target_temperature = int(float(temperature))
+        self.start_watcher()
 
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -386,6 +390,7 @@ class HonClimateEntity(CoordinatorEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str):
         self._attr_fan_mode = fan_mode
         await self._device.settings_command({'windSpeed':CLIMATE_FAN_MODE.get(fan_mode, CLIMATE_FAN_MODE.get(FAN_MEDIUM))}).send()
+        self.start_watcher()
 
 
     async def async_set_swing_mode(self, swing_mode: str):
@@ -414,10 +419,12 @@ class HonClimateEntity(CoordinatorEntity, ClimateEntity):
 
         self._attr_swing_mode = swing_mode
         await self._device.settings_command(parameters).send()
+        self.start_watcher()
 
 
     async def async_will_remove_from_hass(self):
         """When entity will be removed from hass."""
-        if self._watcher != None:
+        if self._watcher is not None:
+            self._watcher()
             self._watcher = None
 


### PR DESCRIPTION
## Summary

Climate (AC) entities did not reflect changes made from Home Assistant: after setting the **target temperature**, **fan mode**, or **swing mode**, the card would not update — or revert to the previous value within one poll cycle (≤60 s). The command itself reached the device (the AC beeped); only the HA state was wrong.

**Root cause:** `async_set_temperature`, `async_set_fan_mode` and `async_set_swing_mode` send the command but never write the new state to HA nor start the existing `start_watcher()` guard, so the next `DataUpdateCoordinator` poll overwrites the local value with the (still stale) cloud "shadow". `async_set_hvac_mode` / `async_turn_on` / `async_turn_off` already do this correctly — this PR aligns the three missing setters with that same pattern.

It also fixes a timer leak in `start_watcher()`.

## Changes

- **Optimistic state + watcher** in `async_set_temperature` (set `_attr_target_temperature`, then `start_watcher()`), `async_set_fan_mode` and `async_set_swing_mode` (call `start_watcher()` after the command). `start_watcher()` already calls `async_write_ha_state()` and suppresses coordinator overwrites for its window.
- **Watcher timer leak fix:** `start_watcher()` used `async_track_time_interval` (a *repeating* timer) whose cancel callback was never invoked — it leaked one timer per command and could clear the guard window early on rapid successive commands. Switched to a one-shot `async_call_later`, cancelling any pending watcher first; `async_will_remove_from_hass` now cancels the pending timer too. Protection window unchanged (8 s).

No new dependencies (`async_call_later` lives in the same `homeassistant.helpers.event` module). Net diff: +10 / −3 in `climate.py`.

## Testing

Tested on live Haier AC units (applianceTypeId 11, integration v0.8.2, HA 2026.x / Python 3.14):
- Target temperature: updates immediately and holds past the 60 s poll (previously reverted).
- Fan mode: holds past the poll.
- Swing mode: holds past the poll (for modes the unit physically supports).
- on/off, HVAC mode and rapid successive commands still behave correctly.
