### PR TITLE
Fix login: migrate to CIAM auth + unified-api appliance list (#322)

### DIFF
--- a/custom_components/hon/const.py
+++ b/custom_components/hon/const.py
@@ -36,7 +36,7 @@ PLATFORMS = [
 
 AUTH_API        = "https://account2.hon-smarthome.com/SmartHome"
 API_URL         = "https://api-iot.he.services"
-APP_VERSION     = "2.0.10"
+APP_VERSION     = "2.27.9"
 OS_VERSION      = 31
 OS              = "android"
 DEVICE_MODEL    = "exynos9820"

--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -4,6 +4,8 @@ import voluptuous as vol
 import aiohttp
 import asyncio
 import secrets
+import hashlib
+import base64
 import json
 import re
 import ast
@@ -25,10 +27,8 @@ from homeassistant.helpers import device_registry as dr
 from .const import (
     DOMAIN,
     CONF_ID_TOKEN,
-    CONF_FRAMEWORK,
     CONF_COGNITO_TOKEN,
     CONF_REFRESH_TOKEN,
-    AUTH_API,
     API_URL,
     APP_VERSION,
     OS_VERSION,
@@ -36,7 +36,8 @@ from .const import (
     DEVICE_MODEL,
 )
 
-SESSION_TIMEOUT     = 21600 # 6 hours session
+# CIAM access tokens expire after ~15 minutes, so refresh well before that.
+SESSION_TIMEOUT     = 600 # seconds
 
 from .base import HonBaseCoordinator
 
@@ -53,16 +54,13 @@ class HonConnection:
         if( email != None ) and ( password != None ):
             self._email = email
             self._password = password
-            self._framework = "None"
         else:
             self._email = entry.data[CONF_EMAIL]
             self._password = entry.data[CONF_PASSWORD]
-            self._framework = entry.data.get(CONF_FRAMEWORK, "")
             self._id_token = entry.data.get(CONF_ID_TOKEN, "")
             self._refresh_token = entry.data.get(CONF_REFRESH_TOKEN, "")
             self._cognitoToken = entry.data.get(CONF_COGNITO_TOKEN, "")
 
-        self._frontdoor_url = ""
         self._start_time    = time.time()
 
         self._header = {
@@ -82,7 +80,7 @@ class HonConnection:
         if mac in self._coordinator_dict:
             return self._coordinator_dict[mac]
         return None
-        
+
     async def async_get_coordinator(self, appliance):
         mac = appliance.get("macAddress", "")
         if mac in self._coordinator_dict:
@@ -92,125 +90,72 @@ class HonConnection:
         return coordinator
 
 
-    async def async_get_frontdoor_url(self, error_code=0):
-
-        data = (
-            "message=%7B%22actions%22%3A%5B%7B%22id%22%3A%2279%3Ba%22%2C%22descriptor%22%3A%22apex%3A%2F%2FLightningLoginCustomController%2FACTION%24login%22%2C%22callingDescriptor%22%3A%22markup%3A%2F%2Fc%3AloginForm%22%2C%22params%22%3A%7B%22username%22%3A%22"
-            + urllib.parse.quote(self._email)
-            + "%22%2C%22password%22%3A%22"
-            + urllib.parse.quote(self._password)
-            + "%22%2C%22startUrl%22%3A%22%22%7D%7D%5D%7D&aura.context=%7B%22mode%22%3A%22PROD%22%2C%22fwuid%22%3A%22"
-            + urllib.parse.quote(self._framework)
-            + "%22%2C%22app%22%3A%22siteforce%3AloginApp2%22%2C%22loaded%22%3A%7B%22APPLICATION%40markup%3A%2F%2Fsiteforce%3AloginApp2%22%3A%22YtNc5oyHTOvavSB9Q4rtag%22%7D%2C%22dn%22%3A%5B%5D%2C%22globals%22%3A%7B%7D%2C%22uad%22%3Afalse%7D&aura.pageURI=%2FSmartHome%2Fs%2Flogin%2F%3Flanguage%3Dfr&aura.token=null"
-        )
-
-        async with self._session.post(
-            f"{AUTH_API}/s/sfsites/aura?r=3&other.LightningLoginCustom.login=1",
-            headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
-            data=data
-        ) as resp:
-            if resp.status != 200:
-                _LOGGER.error("Unable to connect to the login service: " + str(resp.status))
-                return False
-
-            text = await resp.text()
-            try:
-                json_data = json.loads(text)
-                self._frontdoor_url = json_data["events"][0]["attributes"]["values"]["url"]
-            except:
-                # Framework must be updated
-                if text.find("clientOutOfSync") > 0 and error_code != 2:
-                    start = text.find("Expected: ") + 10
-                    end = text.find(" ", start)
-                    _LOGGER.debug("Framework update from ["+ self._framework+ "] to ["+ text[start:end]+ "]")
-                    self._framework = text[start:end]
-                    return await self.async_get_frontdoor_url(2)
-                _LOGGER.error("Unable to retreive the frontdoor URL. Message: " + text)
-                return 1
-
-        if error_code == 2 and self._entry != None:
-            # Update Framework
-            data = {**self._entry.data}
-            data[CONF_FRAMEWORK] = self._framework
-            self._hass.config_entries.async_update_entry(self._entry, data=data)
-
-        return 0
+    async def _ensure_session(self):
+        """Re-authenticate when the CIAM tokens are close to expiring (~15 min TTL)."""
+        if time.time() - self._start_time > SESSION_TIMEOUT:
+            await self.async_authorize()
 
     async def async_authorize(self):
+        """Authenticate against the hOn CIAM endpoint and load the appliances.
 
-        if await self.async_get_frontdoor_url(0) == 1:
-            return False
+        Replaces the legacy Salesforce Aura / OAuth2 login that Haier retired in
+        2026-06: the app now logs in through /ciam/authorize + /ciam/token (PKCE)
+        and reads appliances from /unified-api/v1/view/appliance-list. The old
+        /commands/v1/appliance endpoint now returns an empty list.
+        """
+        # PKCE (S256) verifier + challenge
+        code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b"=").decode()
+        code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode()).digest()
+        ).rstrip(b"=").decode()
 
-        async with self._session.get(self._frontdoor_url) as resp:
+        # 1) Submit credentials, receive a one-time session id
+        params = {
+            "username": self._email,
+            "password": self._password,
+            "code_challenge": code_challenge,
+        }
+        async with self._session.get(f"{API_URL}/ciam/authorize", params=params) as resp:
             if resp.status != 200:
-                _LOGGER.error("Unable to connect to the login service: " + str(resp.status))
+                _LOGGER.error("Unable to connect to the CIAM authorize service: " + str(resp.status))
                 return False
-            await resp.text()
+            session_id = (await resp.json()).get("session_id")
+            if not session_id:
+                _LOGGER.error("Unable to get [session_id] - check your email/password")
+                return False
 
-        url = f"{AUTH_API}/apex/ProgressiveLogin?retURL=%2FSmartHome%2Fapex%2FCustomCommunitiesLanding"
-        async with self._session.get(url) as resp:
-            await resp.text()
-            
-        url = f"{AUTH_API}/services/oauth2/authorize?response_type=token+id_token&client_id=3MVG9QDx8IX8nP5T2Ha8ofvlmjLZl5L_gvfbT9.HJvpHGKoAS_dcMN8LYpTSYeVFCraUnV.2Ag1Ki7m4znVO6&redirect_uri=hon%3A%2F%2Fmobilesdk%2Fdetect%2Foauth%2Fdone&display=touch&scope=api%20openid%20refresh_token%20web&nonce=82e9f4d1-140e-4872-9fad-15e25fbf2b7c"
-        async with self._session.get(url) as resp:
-            text = await resp.text()
-            array = []
+        # 2) Exchange the session id (+ PKCE verifier) for the tokens
+        async with self._session.post(
+            f"{API_URL}/ciam/token",
+            json={"session_id": session_id, "code_verifier": code_verifier},
+        ) as resp:
             try:
-                array = text.split("'", 2)
-
-                if( len(array) == 1 ):
-                    #Implement a second way to get the token value
-                    #m = re.search('id_token\=(.+?)&', text) Works but deprecation warning
-                    m = re.search('id_token\\=(.+?)&', text)
-                    if m:
-                        self._id_token = m.group(1)
-                    else:
-                        _LOGGER.error("Unable to get [id_token] during authorization process (tried both options). Full response [" + text + "]")
-                        return False
-                else:
-                    params = urllib.parse.parse_qs(array[1])
-                    self._id_token = params["id_token"][0]
-            except:
-                if "ChangePassword" not in text:
-                    _LOGGER.error("Unable to get [id_token] during authorization process. Full response [" + text + "]")
-                else:
-                    _LOGGER.error("Unable to get connect. You need to change your password on the hOn app or go to https://account2.hon-smarthome.com/")
+                tokens = (await resp.json())["tokens"]
+                self._cognitoToken = tokens["cognito_token"]
+                self._id_token = tokens["id_token"]
+                self._refresh_token = tokens.get("refresh_token", "")
+            except (KeyError, TypeError):
+                _LOGGER.error("Unable to get tokens from /ciam/token. Response: " + await resp.text())
                 return False
 
-        post_headers = {"id-token": self._id_token}
-        data = {"appVersion": APP_VERSION,
-                "mobileId": self._mobile_id,
-                "os": OS,
-                "osVersion": OS_VERSION,
-                "deviceModel": DEVICE_MODEL}
-
-        async with self._session.post(f"{API_URL}/auth/v1/login", headers=post_headers, json=data) as resp:
+        # 3) Load the appliance list from the unified-api view
+        url = f"{API_URL}/unified-api/v1/view/appliance-list"
+        async with self._session.post(url, headers=self._headers, json={"deviceId": "homeassistant"}) as resp:
             try:
                 json_data = await resp.json()
-                self._cognitoToken = json_data["cognitoUser"]["Token"]
-            except:
-                text = await resp.text()
-                _LOGGER.error("hOn Invalid Data ["+ str(resp.text()) + "] after sending command ["+ str(data)+ "] with headers [" + str(post_headers) + "]. Response: " + text)
+                self._appliances = json_data["modules"]["applianceList"]["payload"]["appliances"]
+            except (KeyError, TypeError):
+                _LOGGER.error("hOn Invalid Data [" + (await resp.text())[:500] + "] after POST [" + url + "]")
                 return False
 
-
-        url = f"{API_URL}/commands/v1/appliance"
-        async with self._session.get(url,headers=self._headers) as resp:
-            try:
-                json_data = await resp.json()
-            except:
-                _LOGGER.error("hOn Invalid Data ["+ str(resp.text()) + "] after GET [" + url + "]")
-                return False
-
-            self._appliances = json_data["payload"]["appliances"]
             _LOGGER.debug(f"All appliances: {self._appliances}")
 
-            ''' Remove appliances with no mac'''
-            self._appliances = [appliance for appliance in self._appliances if "macAddress" in appliance]
+            # Keep only appliances that expose a MAC address and a type id
+            self._appliances = [
+                appliance for appliance in self._appliances
+                if "macAddress" in appliance and "applianceTypeId" in appliance
+            ]
 
-            ''' Remove appliances with no applianceTypeId'''
-            self._appliances = [appliance for appliance in self._appliances if "applianceTypeId" in appliance]
-    
         self._start_time = time.time()
         return True
 
@@ -237,11 +182,8 @@ class HonConnection:
 
     async def async_get_context(self, device):
 
-        # Create a new hOn session to avoid reaching the expiration
-        elapsed_time = time.time() - self._start_time
-        if( elapsed_time > SESSION_TIMEOUT ):
-            self._session.cookie_jar.clear()
-            await self.async_authorize()
+        # Refresh the CIAM session before it expires
+        await self._ensure_session()
 
         params = {
             "macAddress": device.mac_address,
@@ -274,6 +216,8 @@ class HonConnection:
         }
 
     async def async_set(self, mac, typeName, parameters):
+
+        await self._ensure_session()
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         command = json.loads("{}")
@@ -314,6 +258,9 @@ class HonConnection:
 
 
     async def send_command(self, device, command, parameters, ancillary_parameters):
+
+        await self._ensure_session()
+
         now = datetime.utcnow().isoformat()
         command = {
             "macAddress": device.mac_address,
@@ -363,5 +310,3 @@ def get_hOn_mac(device_id, hass):
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
     return next(iter(device.identifiers))[1]
-
-    


### PR DESCRIPTION
## Problem

Since ~2026-06-15 (#322) all entities become `unavailable`. Haier retired two things the integration depends on:

1. The **Salesforce Aura → OAuth2** login flow (`/s/sfsites/aura`, `/apex/ProgressiveLogin`, `/services/oauth2/authorize`).
2. The **`GET /commands/v1/appliance`** list endpoint — it still returns `200`, but with an **empty** `appliances: []`, so no entities are ever created (silently, no error in the log).

## Root cause

It now authenticates through a **CIAM/PKCE** flow and reads appliances from a new **unified-api** endpoint. The per-appliance endpoints (`context`, `retrieve`, `statistics`, `send`) are **unchanged** and keep working with the new tokens.

## Changes

- **Auth** → `GET /ciam/authorize` (username/password + PKCE S256 `code_challenge`) → `session_id`, then `POST /ciam/token` (`session_id` + `code_verifier`) → `{cognito_token, id_token, refresh_token}`. Removes the Aura/OAuth chain, `client_id`, `redirect_uri` and the `fwuid` framework dance.
- **Appliance list** → `POST /unified-api/v1/view/appliance-list {"deviceId": ...}`, parsing `modules.applianceList.payload.appliances`.
- **Token refresh** lowered to 10 min (CIAM tokens expire after ~15 min).
- `context` / `retrieve` / `statistics` / `send` untouched.

## Note for reviewers

The API authorizer reads the `cognito-token` / `id-token` headers **case-sensitively (lowercase)**. `aiohttp` sends them lowercase as written, so this is fine — but a `urllib`-based client that title-cases header names gets a misleading `403 "User is not authorized ... explicit deny in an identity-based policy"`. Worth keeping in mind for anyone debugging.

## Testing

Tested on a live account with my AC units:
- appliances load, `current_temperature` / target / fan / hvac_modes populated via the 60s `context` poll;
- ON/OFF through `POST /commands/v1/send` (`startProgram` / `stopProgram`) returns `resultCode: "0"`.

Fixes #322
