### PR TITLE
Add water_heater platform for WH (Water Heater, applianceTypeId 10)

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -69,6 +69,14 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if device.has("muteStatus"):
             appliances.extend([HonBaseMuteStatus(hass, coordinator, entry, appliance)])
 
+        # WH (Water Heater) additional binary sensors
+        if device.has("heatingStatus"):
+            appliances.extend([HonBaseGenericStatus(hass, coordinator, entry, appliance, "heatingStatus", "Heating", BinarySensorDeviceClass.HEAT)])
+        if device.has("anodeMaintenanceStatus"):
+            appliances.extend([HonBaseGenericStatus(hass, coordinator, entry, appliance, "anodeMaintenanceStatus", "Anode maintenance", BinarySensorDeviceClass.PROBLEM)])
+        if device.has("tankMaintenanceStatus"):
+            appliances.extend([HonBaseGenericStatus(hass, coordinator, entry, appliance, "tankMaintenanceStatus", "Tank maintenance", BinarySensorDeviceClass.PROBLEM)])
+
         # WM additional binary sensors
         if device.has("pause"):
             appliances.extend([HonBasePauseStatus(hass, coordinator, entry, appliance)])

--- a/custom_components/hon/const.py
+++ b/custom_components/hon/const.py
@@ -23,7 +23,8 @@ CONF_REFRESH_TOKEN = "refresh_token"
 CONF_FRAMEWORK = "framework"
 
 PLATFORMS = [
-    "climate", 
+    "climate",
+    "water_heater",
     "sensor",
     "binary_sensor",
     "button",
@@ -47,6 +48,7 @@ class APPLIANCE_TYPE(IntEnum):
     WASHING_MACHINE = 1,
     WASH_DRYER      = 2,
     OVEN            = 4,
+    WATER_HEATER    = 10,
     WINE_COOLER     = 6,
     PURIFIER        = 7,
     TUMBLE_DRYER    = 8,
@@ -60,6 +62,7 @@ APPLIANCE_DEFAULT_NAME = {
     "1": "Washing Machine",
     "2": "Wash Dryer",
     "4": "Oven",
+    "10": "Water Heater",
     "6": "Wine Cooler",
     "7": "Purifier",
     "8": "Tumble Dryer",

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -167,6 +167,14 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if device.has("sterilizationStatus"):
             appliances.extend([HonBaseInt(hass, coordinator, entry, appliance, "sterilizationStatus", "Sterilization status", )])
 
+        # WH (Water Heater) additional sensors
+        if device.has("power"):
+            appliances.extend([HonBasePower(hass, coordinator, entry, appliance)])
+        if device.has("remainingVolumeHotWater"):
+            appliances.extend([HonBaseInt(hass, coordinator, entry, appliance, "remainingVolumeHotWater", "Remaining hot water")])
+        if device.has("totalWorkTime"):
+            appliances.extend([HonBaseWorkTime(hass, coordinator, entry, appliance)])
+
         # WM additional sensors
         if device.has("currentWashCycle"):
             appliances.extend([HonBaseCurrentWashCycle(hass, coordinator, entry, appliance)])
@@ -750,3 +758,29 @@ class HonBaseDelayTime(HonBaseSensorEntity):
 
     def coordinator_update(self):
         self._attr_native_value = self._device.getInt("delayTime")
+
+
+class HonBasePower(HonBaseSensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance) -> None:
+        super().__init__(coordinator, appliance, "power", "Power")
+
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
+        self._attr_device_class = SensorDeviceClass.POWER
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_icon = "mdi:lightning-bolt"
+
+    def coordinator_update(self):
+        self._attr_native_value = self._device.getInt("power")
+
+
+class HonBaseWorkTime(HonBaseSensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance) -> None:
+        super().__init__(coordinator, appliance, "totalWorkTime", "Total work time")
+
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
+        self._attr_device_class = SensorDeviceClass.DURATION
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_icon = "mdi:timer-cog"
+
+    def coordinator_update(self):
+        self._attr_native_value = self._device.getInt("totalWorkTime")

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -236,7 +236,11 @@ class HonBaseMode(HonBaseSensorEntity):
         if( self._type_id == APPLIANCE_TYPE.AIR_TO_WATER ):
             self.translation_key    = "air_to_water_mode"
             self._attr_icon         = "mdi:heat-pump-outline"
-            
+
+        if( self._type_id == APPLIANCE_TYPE.WATER_HEATER ):
+            self.translation_key    = "water_heater_mode"
+            self._attr_icon         = "mdi:water-boiler"
+
 
     def coordinator_update(self):
         mode = self._device.get("machMode")

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -153,6 +153,13 @@
                     "8": "Zones Heat + DHW"
                 }
             },
+            "water_heater_mode" : {
+                "state": {
+                    "1": "Eco",
+                    "2": "Max",
+                    "3": "BPS"
+                }
+            },
             "voc" : {
                 "state": {
                     "1": "Good",

--- a/custom_components/hon/translations/ru.json
+++ b/custom_components/hon/translations/ru.json
@@ -71,6 +71,13 @@
                     "7": "Законченно"
                 }
             },
+            "water_heater_mode" : {
+                "state": {
+                    "1": "Eco",
+                    "2": "Max",
+                    "3": "BPS"
+                }
+            },
             "dry_level" : {
                 "state": {
                     "3": "Cupboard dry",

--- a/custom_components/hon/water_heater.py
+++ b/custom_components/hon/water_heater.py
@@ -1,0 +1,191 @@
+import logging
+from datetime import timedelta
+from typing import Optional
+from datetime import datetime
+
+from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature, PRECISION_WHOLE
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+
+from .const import DOMAIN, APPLIANCE_TYPE
+from .parameter import HonParameterRange
+
+_LOGGER = logging.getLogger(__name__)
+
+# hOn operation modes for water heaters (machMode <-> startProgram program key)
+OP_ECO = "eco"
+OP_MAX = "max"
+OP_BPS = "bps"
+
+# operation name -> machMode value (as reported / accepted by the appliance)
+OPERATION_TO_MACHMODE = {
+    OP_ECO: "1",
+    OP_MAX: "2",
+    OP_BPS: "3",
+}
+MACHMODE_TO_OPERATION = {v: k for k, v in OPERATION_TO_MACHMODE.items()}
+
+
+async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> None:
+
+    hon = hass.data[DOMAIN][entry.unique_id]
+
+    appliances = []
+    for appliance in hon.appliances:
+        if appliance["applianceTypeId"] == APPLIANCE_TYPE.WATER_HEATER:
+            coordinator = await hon.async_get_coordinator(appliance)
+            appliances.append(HonWaterHeaterEntity(hass, coordinator, entry, appliance))
+
+    async_add_entities(appliances)
+
+
+class HonWaterHeaterEntity(CoordinatorEntity, WaterHeaterEntity):
+    def __init__(self, hass, coordinator, entry, appliance) -> None:
+        super().__init__(coordinator)
+        self._coordinator   = coordinator
+        self._hass          = hass
+        self._brand         = appliance["brand"]
+        self._mac           = appliance["macAddress"]
+        self._name          = appliance.get("nickName", appliance.get("modelName", "Water Heater"))
+        self._model         = appliance["modelName"]
+        self._type_name     = appliance["applianceTypeName"]
+        self._fw_version    = appliance["fwVersion"]
+        self._unique_id     = f"{self._mac}_water_heater"
+        self._device        = coordinator.device
+        self._watcher       = None
+
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._attr_operation_list = [STATE_OFF, OP_ECO, OP_MAX, OP_BPS]
+        self._attr_supported_features = (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.OPERATION_MODE
+            | WaterHeaterEntityFeature.ON_OFF
+        )
+
+        # Read the allowed target-temperature range from the live `settings` command
+        # (tempSel: 30-85 step 1 on the ES80V-F7). Falls back to sane defaults.
+        self._attr_target_temperature_step = PRECISION_WHOLE
+        self._attr_min_temp = 30
+        self._attr_max_temp = 85
+        try:
+            temp_range = self._device.settings_command().parameters.get("tempSel")
+            if isinstance(temp_range, HonParameterRange):
+                self._attr_min_temp = temp_range.min
+                self._attr_max_temp = temp_range.max
+                self._attr_target_temperature_step = temp_range.step
+        except Exception as e:  # pragma: no cover - defensive, keep entity alive
+            _LOGGER.warning("WH: unable to read tempSel range: %s", e)
+
+        self._update_from_device(write=False)
+
+    # ----- helpers -------------------------------------------------------
+
+    def _is_on(self) -> bool:
+        return self._device.get("onOffStatus") == "1"
+
+    def start_watcher(self, delay=timedelta(seconds=8)):
+        """Suppress coordinator overwrites briefly so optimistic state sticks."""
+        if self._watcher is not None:
+            self._watcher()
+        self._watcher = async_track_time_interval(
+            self._hass, self._clear_watcher, delay
+        )
+
+    async def _clear_watcher(self, now: Optional[datetime] = None) -> None:
+        if self._watcher is not None:
+            self._watcher()
+        self._watcher = None
+        await self._coordinator.async_request_refresh()
+
+    def _update_from_device(self, write=True):
+        self._attr_current_temperature = float(self._device.get("temp") or 0)
+        self._attr_target_temperature = float(self._device.get("tempSel") or 0)
+
+        if not self._is_on():
+            self._attr_current_operation = STATE_OFF
+        else:
+            self._attr_current_operation = MACHMODE_TO_OPERATION.get(
+                str(self._device.get("machMode")), OP_ECO
+            )
+        if write:
+            self.async_write_ha_state()
+
+    # ----- coordinator ---------------------------------------------------
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        # Watcher running: data may still reflect the pre-command state
+        if self._watcher is not None:
+            return
+        if self._coordinator.data is False:
+            return
+        self._update_from_device()
+
+    # ----- commands ------------------------------------------------------
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+        await self._device.settings_command({"tempSel": int(temperature)}).send()
+        self._attr_target_temperature = int(temperature)
+        self.start_watcher()
+        self.async_write_ha_state()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        if operation_mode == STATE_OFF:
+            await self._device.stop_command().send()
+        elif self._is_on():
+            # Live mode change keeps the current target temperature
+            machmode = OPERATION_TO_MACHMODE[operation_mode]
+            await self._device.settings_command({"machMode": machmode}).send()
+        else:
+            # Powered off: (re)start with the matching program
+            await self._device.start_command(operation_mode).send()
+        self._attr_current_operation = operation_mode
+        self.start_watcher()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs) -> None:
+        program = MACHMODE_TO_OPERATION.get(str(self._device.get("machMode")), OP_ECO)
+        await self._device.start_command(program).send()
+        self._attr_current_operation = program
+        self.start_watcher()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._device.stop_command().send()
+        self._attr_current_operation = STATE_OFF
+        self.start_watcher()
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self):
+        if self._watcher is not None:
+            self._watcher()
+            self._watcher = None
+
+    # ----- attributes ----------------------------------------------------
+
+    @property
+    def unique_id(self) -> str:
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._mac, self._type_name)},
+            "name": self._name,
+            "manufacturer": self._brand,
+            "model": self._model,
+            "sw_version": self._fw_version,
+        }

--- a/custom_components/hon/water_heater.py
+++ b/custom_components/hon/water_heater.py
@@ -19,18 +19,16 @@ from .parameter import HonParameterRange
 
 _LOGGER = logging.getLogger(__name__)
 
-# hOn operation modes for water heaters (machMode <-> startProgram program key)
-OP_ECO = "eco"
-OP_MAX = "max"
-OP_BPS = "bps"
-
-# operation name -> machMode value (as reported / accepted by the appliance)
-OPERATION_TO_MACHMODE = {
-    OP_ECO: "1",
-    OP_MAX: "2",
-    OP_BPS: "3",
+# hOn operation modes for water heaters.
+# The capitalized display name doubles as the HA operation_mode value (HA only
+# localizes the *standard* water_heater states, so custom modes must already be
+# nicely cased). Each maps to (machMode value, startProgram program key).
+WH_MODES = {
+    "Eco": ("1", "eco"),
+    "Max": ("2", "max"),
+    "BPS": ("3", "bps"),
 }
-MACHMODE_TO_OPERATION = {v: k for k, v in OPERATION_TO_MACHMODE.items()}
+MACHMODE_TO_MODE = {machmode: name for name, (machmode, _prog) in WH_MODES.items()}
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> None:
@@ -62,7 +60,7 @@ class HonWaterHeaterEntity(CoordinatorEntity, WaterHeaterEntity):
         self._watcher       = None
 
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        self._attr_operation_list = [STATE_OFF, OP_ECO, OP_MAX, OP_BPS]
+        self._attr_operation_list = [STATE_OFF, *WH_MODES.keys()]
         self._attr_supported_features = (
             WaterHeaterEntityFeature.TARGET_TEMPERATURE
             | WaterHeaterEntityFeature.OPERATION_MODE
@@ -111,8 +109,8 @@ class HonWaterHeaterEntity(CoordinatorEntity, WaterHeaterEntity):
         if not self._is_on():
             self._attr_current_operation = STATE_OFF
         else:
-            self._attr_current_operation = MACHMODE_TO_OPERATION.get(
-                str(self._device.get("machMode")), OP_ECO
+            self._attr_current_operation = MACHMODE_TO_MODE.get(
+                str(self._device.get("machMode")), "Eco"
             )
         if write:
             self.async_write_ha_state()
@@ -141,21 +139,22 @@ class HonWaterHeaterEntity(CoordinatorEntity, WaterHeaterEntity):
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         if operation_mode == STATE_OFF:
             await self._device.stop_command().send()
-        elif self._is_on():
-            # Live mode change keeps the current target temperature
-            machmode = OPERATION_TO_MACHMODE[operation_mode]
-            await self._device.settings_command({"machMode": machmode}).send()
         else:
-            # Powered off: (re)start with the matching program
-            await self._device.start_command(operation_mode).send()
+            machmode, program = WH_MODES[operation_mode]
+            if self._is_on():
+                # Live mode change keeps the current target temperature
+                await self._device.settings_command({"machMode": machmode}).send()
+            else:
+                # Powered off: (re)start with the matching program
+                await self._device.start_command(program).send()
         self._attr_current_operation = operation_mode
         self.start_watcher()
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs) -> None:
-        program = MACHMODE_TO_OPERATION.get(str(self._device.get("machMode")), OP_ECO)
-        await self._device.start_command(program).send()
-        self._attr_current_operation = program
+        mode = MACHMODE_TO_MODE.get(str(self._device.get("machMode")), "Eco")
+        await self._device.start_command(WH_MODES[mode][1]).send()
+        self._attr_current_operation = mode
         self.start_watcher()
         self.async_write_ha_state()
 


### PR DESCRIPTION
### Water Heater
Model Id: 265
Model Name: ES80V-F7

- New water_heater.py: WaterHeaterEntity with target temperature, operation modes (eco/max/bps) and on/off, backed by the existing settings/startProgram/stopProgram commands.
- Register the "water_heater" platform and WH appliance type (10).
- Surface WH read-only entities: Heating / maintenance binary sensors and Power / Remaining hot water / Total work time sensors.

<img width="1755" height="1016" alt="image" src="https://github.com/user-attachments/assets/f7c175db-08f5-4ac0-aefe-71d1873d1711" />
