### PR TITLE
Update air_to_water_mode states in English translations

### DIFF
--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -125,6 +125,17 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
             appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
             await coordinator.async_request_refresh()
 
+        if (("settings" in device.commands) 
+            and (device.get("ecoMode", "N/A") != "N/A")):
+
+            description = HonSwitchEntityDescription(
+                key="turboMode",
+                name="Turbo Mode",
+                icon="mdi:rocket-launch",
+                translation_key="turbo_mode",
+            )
+            appliances.extend([HonSwitchEntity(hass, coordinator, entry, appliance, description)])
+            await coordinator.async_request_refresh()
 
         if (("settings" in device.commands) 
             and (device.get("healthMode", "N/A") != "N/A")):

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -147,10 +147,15 @@
             },
             "air_to_water_mode" : {
                 "state": {
-                    "0": "Off",
-                    "2": "Zones Heat",
+                    "0": "Auto",
+                    "1": "Cooling",
+                    "2": "Heating",
                     "3": "DHW",
-                    "8": "Zones Heat + DHW"
+                    "4": "Pool",
+                    "5": "Heating + Pool",
+                    "6": "Auto + DHW",
+                    "7": "Cooling + DHW",
+                    "8": "Heating + DHW"
                 }
             },
             "voc" : {

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -121,6 +121,12 @@
                     "6": "Fan only"
                 }
             },
+            "holiday_mode": {
+                "state": {
+                    "0": "Off",
+                    "1": "On",
+                }
+            },
             "dishwasher_mode" : {
                 "state": {
                     "1": "Ready",

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -121,12 +121,14 @@
                     "6": "Fan only"
                 }
             },
+            
             "holiday_mode": {
                 "state": {
                     "0": "Off",
-                    "1": "On",
+                    "1": "On"
                 }
             },
+            
             "dishwasher_mode" : {
                 "state": {
                     "1": "Ready",


### PR DESCRIPTION
To match parameter definitions from Haier service manual and include missing values:
0- Auto, 1- Cooling, 2- Heating, 3- DHW, 4- Pool, 5- Heating + Pool, 6- Auto + DHW, 7- Cooling + DHW, 8- Heating + DHW