### PR TITLE
Fixes program name as per app

### DIFF
--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -242,6 +242,7 @@ class HonConnection:
         command["parameters"] = parameters
         command["timestamp"] = timestamp
         command["transactionId"] = mac + "_" + command["timestamp"]
+        
         _LOGGER.debug((f"Command sent (async_set): {command}"))
 
         async with self._session.post(f"{API_URL}/commands/v1/send",headers=self._headers,json=command,) as resp:
@@ -284,6 +285,15 @@ class HonConnection:
             "parameters": parameters,
             "applianceType": device.appliance_type
         }
+        
+        program = parameters.get("program") or ancillary_parameters.get("program")
+
+        if command["commandName"] == "startProgram" and program:
+            if device.appliance_type in ["WM", "WD"]:
+                command["programName"] = (
+                    f"PROGRAMS.WM_WD.{program.upper()}"
+                )
+            
         _LOGGER.debug((f"Command sent (send_command): {command}"))
 
         url = f"{API_URL}/commands/v1/send"


### PR DESCRIPTION
I noticed program names haven't been appearing on my machine display, or the app or within hOn integration. 

After using mitmproxy, it seems that `program` is no longer used, but rather `programName`. Probably an attempt at sabotage by hOn devs.

<img width="563" height="640" alt="image" src="https://github.com/user-attachments/assets/85be218d-fa25-4042-bad1-254bf391384a" />

Have updated accordingly.

## This branch (after send command):
<img width="593" height="515" alt="image" src="https://github.com/user-attachments/assets/9f230513-e6d9-4afe-af92-559dcbe5a0eb" />

<img width="1206" height="1893" alt="image" src="https://github.com/user-attachments/assets/6579d63e-2f90-446e-a1cc-bf0ff52c4fa2" />

## 0.8.4 (after send command):
<img width="593" height="515" alt="image" src="https://github.com/user-attachments/assets/4ec64ad4-9745-4473-a2b1-9a7ff083292c" />

<img width="1206" height="2422" alt="image" src="https://github.com/user-attachments/assets/2d06eda0-e8a2-45aa-aad6-c7b3fc7390d3" />

