### PR TITLE
Fix KeyError when appliance has no "series" field

### DIFF
--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -170,7 +170,7 @@ class HonConnection:
             "fwVersion": appliance["fwVersion"],
             "os": OS,
             "appVersion": APP_VERSION,
-            "series": appliance["series"],
+            "series": appliance.get("series", ""),
         }
         url = f"{API_URL}/commands/v1/retrieve"
         async with self._session.get(url, params=params, headers=self._headers) as resp:


### PR DESCRIPTION
Some hOn appliances do not return a `series` key in their appliance info.
When building the `commands/v1/retrieve` request, accessing `appliance["series"]` directly raised a KeyError and broke command retrieval for those devices.

Use `appliance.get("series", "")` with an empty-string fallback instead.