### PR TITLE
Handle appliances without a command set (e.g. TVs) gracefully

### DIFF
--- a/custom_components/hon/device.py
+++ b/custom_components/hon/device.py
@@ -287,10 +287,19 @@ class HonDevice(CoordinatorEntity):
 
     async def load_commands(self):
         commands = await self._hon.load_commands(self._appliance)
-    
+
+        if not commands:
+            # Some appliances (e.g. a Haier TV) legitimately return no command
+            # set. That's a normal state, not an error worth alarming about.
+            _LOGGER.debug(
+                "No command set returned for %s (type %s); skipping command setup.",
+                self._name, self._type_name,
+            )
+            return
+
         try:
             self._appliance_model = commands.pop("applianceModel")
-        except:
+        except KeyError:
             _LOGGER.error(f"Unable to load device commands. Please try to restart. Current value: [{commands}]")
             return
 

--- a/custom_components/hon/hon.py
+++ b/custom_components/hon/hon.py
@@ -174,8 +174,24 @@ class HonConnection:
         }
         url = f"{API_URL}/commands/v1/retrieve"
         async with self._session.get(url, params=params, headers=self._headers) as resp:
+            if resp.status != 200:
+                _LOGGER.warning(
+                    "Command retrieve failed for %s (HTTP %s)",
+                    appliance.get("macAddress"), resp.status,
+                )
+                return {}
             result = (await resp.json()).get("payload", {})
-            if not result or result.pop("resultCode") != "0":
+            if not result:
+                # Appliance without a command set (e.g. a TV): the cloud returns
+                # an empty payload. This is expected, so stay quiet here and let
+                # the caller skip command setup.
+                return {}
+            result_code = result.pop("resultCode", None)
+            if result_code != "0":
+                _LOGGER.warning(
+                    "Command retrieve returned resultCode %s for %s",
+                    result_code, appliance.get("macAddress"),
+                )
                 return {}
             _LOGGER.debug(f"Commands: {result}")
             return result


### PR DESCRIPTION
Some hOn appliances — a Haier TV (`applianceType: "TV"`) in my case — legitimately return an **empty command-retrieve payload**. On every startup and integration reload this produced a noisy, misleading error:

```
ERROR [custom_components.hon.device] Unable to load device commands. Please try to restart. Current value: [{}]
```

### Root cause
- `hon.py` `load_commands()` collapses both a *real* API failure and a *legitimately empty* payload into `{}`.
- `device.py` `load_commands()` then does `commands.pop("applianceModel")` inside a **bare `except:`**, so the resulting `KeyError` is logged as an ERROR even though, for a TV, having no program/command set is a perfectly normal state.

### Changes
- **`device.py`**: guard for an empty command set → log at `DEBUG` and skip command setup; narrow the bare `except:` to `except KeyError` so genuine malformed payloads are still surfaced.
- **`hon.py`**: distinguish a real API failure (`HTTP != 200` / `resultCode != "0"`, logged at `WARNING`) from a legitimately empty payload (returned quietly). No behavioural change for appliances that do return commands.

### Verification (live, with debug logging)
Three linked appliances — dishwasher (DW), washing machine (WM) and a TV:
- WM and DW still load their `Commands` and expose program entities (no regression).
- The TV now logs `DEBUG ... No command set returned for Living Room TV (type TV); skipping command setup.` instead of the ERROR.
- The `Unable to load device commands` ERROR no longer appears on startup or reload.