### PR TITLE
Add support to zone power settings

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -97,6 +97,16 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if device.has("ecoExpress"):
             appliances.extend([HonBaseGenericStatus(hass, coordinator, entry, appliance, "ecoExpress", "Eco express", BinarySensorDeviceClass.RUNNING)])
 
+        # Induction Hob (HAISJ64MC) settings
+        for i in range(1, 5):
+           if device.has(f"onOffStatusZ{i}"):
+              appliances.extend([HonHobZoneOnOff(hass, coordinator, entry, appliance, f"onOffStatusZ{i}", f"Zone {i} State")])
+           if device.has(f"panStatusZ{i}"):
+              appliances.extend([HonHobZonePanPresence(hass, coordinator, entry, appliance, f"panStatusZ{i}", f"Zone {i} Pan")])
+           if device.has(f"hotStatusZ{i}"):
+              appliances.extend([HonHobZoneHotStatus(hass, coordinator, entry, appliance, f"hotStatusZ{i}", f"Zone {i} Hot")])
+
+
     async_add_entities(appliances)
 
 
@@ -208,3 +218,35 @@ class HonBasePauseStatus(HonBaseBinarySensorEntity):
 
     def coordinator_update(self):
         self._attr_is_on = self._device.get("pause") == "1"
+
+
+class HonHobZoneOnOff(HonBaseBinarySensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
+        super().__init__(coordinator, appliance, key, name)
+
+        self._attr_device_class = BinarySensorDeviceClass.POWER
+
+    def coordinator_update(self):
+        self._attr_is_on = self._device.get(self._key) == "1" 
+
+
+class HonHobZonePanPresence(HonBaseBinarySensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
+        super().__init__(coordinator, appliance, key, name)
+            
+        self._attr_device_class = BinarySensorDeviceClass.PRESENCE
+        self._attr_icon = "mdi:pot-steam"
+
+    def coordinator_update(self):
+        self._attr_is_on = self._device.get(self._key) == "1" 
+
+
+class HonHobZoneHotStatus(HonBaseBinarySensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
+        super().__init__(coordinator, appliance, key, name)
+        
+        self._attr_device_class = BinarySensorDeviceClass.HEAT
+        self._attr_icon = "mdi:thermometer-chevron-up"
+
+    def coordinator_update(self):
+        self._attr_is_on = self._device.get(self._key) == "1" 

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -76,12 +76,16 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempSelZ2",   "Selected temperature zone 2")])
         if device.has("tempSelZ3"):
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempSelZ3",   "Selected temperature zone 3")])
+        if device.has("tempSelZ4"):
+            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempSelZ4",   "Selected temperature zone 4")])
         if device.has("tempZ1"):
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ1",      "Temperature zone 1")])
         if device.has("tempZ2"):
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ2",      "Temperature zone 2")])
         if device.has("tempZ3"):
             appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ3",      "Temperature zone 3")])
+        if device.has("tempZ4"):
+            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ4",      "Temperature zone 4")])
 
         # AW Domestic hot water sensors
         if device.has("tempDhw"):
@@ -200,6 +204,16 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
             appliances.extend([HonBaseVolume(hass, coordinator, entry, appliance)])
         if device.has("displayedApp"):
             appliances.extend([HonBaseDisplayedApp(hass, coordinator, entry, appliance)])
+
+        # Cooking Hob     
+        if device.has("powerZ1"):
+            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ1", "Power zone 1")])
+        if device.has("powerZ2"):
+            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ2", "Power zone 2")])
+        if device.has("powerZ3"):
+            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ3", "Power zone 3")])
+        if device.has("powerZ4"):
+            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ4", "Power zone 4")])
 
         # Statistics sensors
         if device.get("statistics.programsCounter") is not None:

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -205,25 +205,21 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if device.has("displayedApp"):
             appliances.extend([HonBaseDisplayedApp(hass, coordinator, entry, appliance)])
 
-        # Cooking Hob     
-        if device.has("powerZ1"):
-            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ1", "Power zone 1")])
-        if device.has("powerZ2"):
-            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ2", "Power zone 2")])
-        if device.has("powerZ3"):
-            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ3", "Power zone 3")])
-        if device.has("powerZ4"):
-            appliances.extend([HonBasePowerZone(hass, coordinator, entry, appliance, "powerZ4", "Power zone 4")])
-
         # Statistics sensors
         if device.get("statistics.programsCounter") is not None:
             appliances.extend([HonBaseProgramsCounter(hass, coordinator, entry, appliance)])
 
+       # Induction Hob (HAISJ64MC) settings
+        for i in range(1, 5):
+            if device.has(f"powerZ{i}"):
+                appliances.extend([HonHobZoneLevel(hass, coordinator, entry, appliance, f"powerZ{i}", f"Zone {i} Level")])
+            if device.has(f"remainingTimeHHZ{i}") and device.has(f"remainingTimeMMZ{i}"):
+                appliances.extend([HonHobZoneCompositeTimer(hass, coordinator, entry, appliance, i, f"Zone {i} Timer")])
+
+
         await coordinator.async_request_refresh()
 
     async_add_entities(appliances)
-
-
 
 
 
@@ -803,7 +799,8 @@ class HonBaseWorkTime(HonBaseSensorEntity):
     def coordinator_update(self):
         self._attr_native_value = self._device.getInt("totalWorkTime")
 
-class HonBasePowerZone(HonBaseSensorEntity):
+
+class HonHobZoneLevel(HonBaseSensorEntity):
     def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
         super().__init__(coordinator, appliance, key, name)
         self._attr_icon = "mdi:stove"
@@ -811,3 +808,21 @@ class HonBasePowerZone(HonBaseSensorEntity):
 
     def coordinator_update(self):
         self._attr_native_value = self._device.getInt(self._key)
+
+
+class HonHobZoneCompositeTimer(HonBaseSensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance, zone_number, name) -> None:
+        self._zone_number = zone_number
+
+        super().__init__(coordinator, appliance, f"remainingTimeMMZ{zone_number}", name)
+        self._attr_icon = "mdi:timer-outline"
+        self._attr_native_unit_of_measurement = "min"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    def coordinator_update(self):
+        hours = self._device.getInt(f"remainingTimeHHZ{self._zone_number}")
+        minutes = self._device.getInt(f"remainingTimeMMZ{self._zone_number}")
+        
+        # Adds hours and minutes (HH * 60 + MM)
+        self._attr_native_value = (hours * 60) + minutes
+

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -802,3 +802,12 @@ class HonBaseWorkTime(HonBaseSensorEntity):
 
     def coordinator_update(self):
         self._attr_native_value = self._device.getInt("totalWorkTime")
+
+class HonBasePowerZone(HonBaseSensorEntity):
+    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
+        super().__init__(coordinator, appliance, key, name)
+        self._attr_icon = "mdi:stove"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    def coordinator_update(self):
+        self._attr_native_value = self._device.getInt(self._key)


### PR DESCRIPTION
Reported on https://github.com/gvigroux/hon/issues/340 
### The Problem
For Haier Induction Hobs (Appliance type: IH), specifically model HAISJ64MC, the integration code in `sensor.py` tries to map entities to `tempZ1`, `tempZ2`, and `tempZ3`. 

However, in the tested Haier Hob appliance telemetry firmware, these `tempZX` registers are stale (frozen at 0 since the appliance was registered in hOn). Furthermore, `tempZ4` is entirely missing from the loop in `sensor.py`, leaving 4-zone hobs with only 3 blind entities.

The real-time operational power levels are sent inside the shadow payload under `powerZ1`, `powerZ2`, `powerZ3`, and `powerZ4`.

### Proposed Fix
The integration should expose the `powerZX` telemetry amongst other settings.

Adds a section to explicitly register `powerZ{i}` variables in `sensor.py`:
```python
       # Induction Hob (HAISJ64MC) settings
        for i in range(1, 5):
            if device.has(f"powerZ{i}"):
                appliances.extend([HonHobZoneLevel(hass, coordinator, entry, appliance, f"powerZ{i}", f"Zone {i} Level")])
            if device.has(f"remainingTimeHHZ{i}") and device.has(f"remainingTimeMMZ{i}"):
                appliances.extend([HonHobZoneCompositeTimer(hass, coordinator, entry, appliance, i, f"Zone {i} Timer")])
```

And new helper classes to read the dynamic state:

```python

class HonHobZoneLevel(HonBaseSensorEntity):
    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
        super().__init__(coordinator, appliance, key, name)
        self._attr_icon = "mdi:stove"
        self._attr_state_class = SensorStateClass.MEASUREMENT

    def coordinator_update(self):
        self._attr_native_value = self._device.getInt(self._key)


class HonHobZoneCompositeTimer(HonBaseSensorEntity):
    def __init__(self, hass, coordinator, entry, appliance, zone_number, name) -> None:
        self._zone_number = zone_number

        super().__init__(coordinator, appliance, f"remainingTimeMMZ{zone_number}", name)
        self._attr_icon = "mdi:timer-outline"
        self._attr_native_unit_of_measurement = "min"
        self._attr_state_class = SensorStateClass.MEASUREMENT

    def coordinator_update(self):
        hours = self._device.getInt(f"remainingTimeHHZ{self._zone_number}")
        minutes = self._device.getInt(f"remainingTimeMMZ{self._zone_number}")
        
        # Adds hours and minutes (HH * 60 + MM)
        self._attr_native_value = (hours * 60) + minutes
```

the missing temperature zone4 is fixed (although not used in the test appliance) with:
```python
        if device.has("tempSelZ4"):
            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempSelZ4",   "Selected temperature zone 4")])
(...)
        if device.has("tempZ4"):
            appliances.extend([HonBaseTemperature(hass, coordinator, entry, appliance, "tempZ4",      "Temperature zone 4")])
(...)
```

It also includes a set of new binary sensors extending the already present sensors.
`binary_sensor.py` is updated with:
```python
        # Induction Hob (HAISJ64MC) settings
        for i in range(1, 5):
           if device.has(f"onOffStatusZ{i}"):
              appliances.extend([HonHobZoneOnOff(hass, coordinator, entry, appliance, f"onOffStatusZ{i}", f"Zone {i} State")])
           if device.has(f"panStatusZ{i}"):
              appliances.extend([HonHobZonePanPresence(hass, coordinator, entry, appliance, f"panStatusZ{i}", f"Zone {i} Pan")])
           if device.has(f"hotStatusZ{i}"):
              appliances.extend([HonHobZoneHotStatus(hass, coordinator, entry, appliance, f"hotStatusZ{i}", f"Zone {i} Hot")])
```

And new helper classes to read the dynamic state:

```python
class HonHobZoneOnOff(HonBaseBinarySensorEntity):
    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
        super().__init__(coordinator, appliance, key, name)

        self._attr_device_class = BinarySensorDeviceClass.POWER

    def coordinator_update(self):
        self._attr_is_on = self._device.get(self._key) == "1" 


class HonHobZonePanPresence(HonBaseBinarySensorEntity):
    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
        super().__init__(coordinator, appliance, key, name)
            
        self._attr_device_class = BinarySensorDeviceClass.PRESENCE
        self._attr_icon = "mdi:pot-steam"

    def coordinator_update(self):
        self._attr_is_on = self._device.get(self._key) == "1" 


class HonHobZoneHotStatus(HonBaseBinarySensorEntity):
    def __init__(self, hass, coordinator, entry, appliance, key, name) -> None:
        super().__init__(coordinator, appliance, key, name)
        
        self._attr_device_class = BinarySensorDeviceClass.HEAT
        self._attr_icon = "mdi:thermometer-chevron-up"

    def coordinator_update(self):
        self._attr_is_on = self._device.get(self._key) == "1" 
```



