### PR TITLE
Feature/enable select platform

### DIFF
--- a/custom_components/hon/const.py
+++ b/custom_components/hon/const.py
@@ -28,11 +28,12 @@ PLATFORMS = [
     "sensor",
     "binary_sensor",
     "button",
+    "select",
     "switch"
 ]
 
 """     "number",
-    "select", """
+        """
 
 
 AUTH_API        = "https://account2.hon-smarthome.com/SmartHome"

--- a/custom_components/hon/select.py
+++ b/custom_components/hon/select.py
@@ -36,9 +36,11 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         coordinator = await hon.async_get_coordinator(appliance)
 
         for key, parameter in coordinator.device.settings.items():
+            if not key.startswith("settings."):
+                continue
             if not isinstance(parameter, (HonParameterEnum, HonParameterProgram)):
                 continue
-            if key.startswith("settings.") and set(parameter.values) == {"0", "1"}:
+            if set(parameter.values) == {"0", "1"}:
                 continue
 
             default_value = default_values.get(parameter.key, {})
@@ -79,6 +81,10 @@ class HonSelect(HonDevice, SelectEntity):
             self._attr_options = [setting.value]
         else:
             self._attr_options = list(setting.values)
+
+    @property
+    def name(self):
+        return f"{self._device.name} {self.entity_description.name}"
 
     @property
     def current_option(self) -> str | None:


### PR DESCRIPTION
## Summary

Enables the `select` platform. `select.py` is already implemented but commented out of `PLATFORMS`; two small fixes were needed to make it usable.

This exposes enum settings — `windDirectionVertical`, `windDirectionHorizontal`, `windSpeed`, `machMode` — as `select` entities in the device's Configuration section. Today they are read-only attributes on the `climate` entity and can only be changed through a manual service call.

## Changes

**`const.py`** — add `"select"` to `PLATFORMS`.

**`select.py`** — only expose parameters coming from the `settings` command:

```python
if not key.startswith("settings."):
    continue
```

`HonDevice.settings` flattens every command into `f"{command_name}.{key}"`, so a single parameter can appear as both `settings.windSpeed` and `startProgram.windSpeed`. The `startProgram.*` variants don't work anyway — in `async_select_option` only the `settings` branch calls `.send()`, so clicking them does nothing — and they duplicate `parameter.key`, which produces several identically named entities per device.

**`select.py`** — override `name` on `HonSelect`:

```python
@property
def name(self):
    return f"{self._device.name} {self.entity_description.name}"
```

`HonSelect` inherits from `HonDevice`, whose `name` property precedes `Entity.name` in the MRO. Without this override every select entity was named after the device instead of its parameter.

`"number"` is intentionally left disabled — `number.py` registers duplicate `unique_id`s. Separate fix.

## Testing

Tested on AS25S2SF1FA-WH (`applianceTypeId: 11`): entities appear with distinct names, changing a value sends the command, and the new state is reflected after the next refresh. The `climate` entity is unaffected.

## Known limitation

No translation keys exist for these parameters, so options render as raw values (`"1"`–`"8"`). The mapping already exists in `const.py` as `ClimateSwingVertical` — could be a follow-up.